### PR TITLE
Enhance command execution flow and handle SIGINT in heredoc (#113)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -47,11 +47,24 @@ static void	parse_and_execute(t_msh *msh, char *line)
 		msh->exit_status = 127;
 		return ;
 	}
-	msh->exit_status = parser(line, msh);
+	if (parser(line, msh) != 0)
+	{
+		clear_command_chain(msh->command);
+		msh->command = NULL;
+		add_history(line);
+		return;
+	}
+
 	msh->num_cmds = count_commands(msh->command);
-//	if (!process(msh)) // TODO wrap in if success?
-//		return ;
-	process(msh);
+
+	if (!process(msh))
+	{
+		clear_command_chain(msh->command);
+		msh->command = NULL;
+		add_history(line);
+		return;
+	}
+
 	clear_command_chain(msh->command);
 	msh->command = NULL;
 	add_history(line);

--- a/src/redirections/heredoc.c
+++ b/src/redirections/heredoc.c
@@ -19,11 +19,17 @@ int	handle_heredoc(t_command *command, t_msh *msh)
 	while (1)
 	{
 		line = readline("> ");
+		if (g_signal_code == SIGINT)
+		{
+			msh->exit_status = 130;
+			if (line)
+				free(line);
+			close(pipe_fd[1]);
+			return (0); // Indicate interruption
+		}
 		if (!line)
 		{
-			//TODO too many semicolon
 			ft_perror(command, NULL, 1, "warning: here-document delimited by end-of-file");
-			free(line);
 			break ;
 		}
 		if (is_equal(line, command->heredoc_delimiter))


### PR DESCRIPTION
* Improved error handling in parse_and_execute to clear command chain and add history on parser or process failure.
* Added SIGINT handling in handle_heredoc to set exit status and clean up resources on interruption.