### PR TITLE
Changed exit_shell behaviour to set the msh->exit flag to 1, thus let…

### DIFF
--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -18,10 +18,11 @@ void	exit_shell(t_msh *msh, t_command *command)
 		else
 			msh->exit_status = 0;
 	}
-	clear_command_chain(msh->command);
-	clean_myenv(msh->myenv);
-	rl_clear_history();
+//	clear_command_chain(msh->command);
+	//clean_myenv(msh->myenv);
+//	rl_clear_history();
 	if (msh->num_cmds < 2)
 		ft_putstr_fd("exit\n", STDERR_FILENO);
-	exit(msh->exit_status);
+	msh->exit = 1;
+//	exit(msh->exit_status);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -74,6 +74,7 @@ int	main(int argc, char **argv, char **envp)
 {
 	char	*line;
 	t_msh	msh;
+	int	exit_code;
 
 	(void)argc;
 	(void)argv;
@@ -89,12 +90,17 @@ int	main(int argc, char **argv, char **envp)
 		g_signal_code = -1;
 		set_signals_child();
 		if (!line)
-			exit_shell(&msh, NULL);
+		{
+			msh.exit = 1;
+			break ;
+		}
 		if (ft_strlen(line) != 0)
 			parse_and_execute(&msh, line);
 		free(line);
 	}
-	return (exit_shell(&msh, NULL), 0);
+	exit_code = msh.exit_status;
+	cleanup(&msh);
+	exit(exit_code);
 }
 /*
 int	main(int argc, char **argv)


### PR DESCRIPTION
…ting the single_parent_process run to the end and close its open fds when using the exit builtin